### PR TITLE
Added Iris compatibility (albeit without texture affine map clamping), overhauled README.md documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Place the cloned repository folder or downloaded zip file in your `shaderpacks` 
 ## Known Issues
 * Beacon beams tilt and do weird things when terrain vertex snapping is on due to [OptiFine issue #4905](https://github.com/sp614x/optifine/issues/4905) (sp614x/optifine#4905).  If anyone knows the block entity ID of beacon beams or whatever it is to single it out in gbuffers_block, please let me know.
 
-* Texture affine map clamping ("Clamp Texcoord Bounds (OptiFine only)") is disabled by default in order to ensure that texture affine mapping works at all for Iris users. OptiFine users may want to re-enable this option in order to avoid extreme texture stretching on some geometry close to the camera at certain angles.
-	* The reason why this feature is broken is because it requires the use of a custom GLSL uniform (`texelSize`), but custom uniforms are not supported on Iris yet — see [Iris issue #1027](https://github.com/IrisShaders/Iris/issues/1027) (IrisShaders/Iris#1027).
-
 * Texture affine mapping behaviour on Iris does not exactly match that of OptiFine's. All affine mapped textures on Iris warp in the opposite direction compared to OptiFine, though this is not noticeable without comparing the two side-by-side.
 
 * In-universe text (signs, player/entity name tags, etc.) is difficult, if not nearly impossible to read. UI text and rendering are unaffected.

--- a/README.md
+++ b/README.md
@@ -19,5 +19,7 @@ Place the cloned repository folder or downloaded zip file in your `shaderpacks` 
 
 * Texture affine mapping behaviour on Iris does not exactly match that of OptiFine's. All affine mapped textures on Iris warp in the opposite direction compared to OptiFine, though this is not noticeable without comparing the two side-by-side.
 
+* In-universe text (signs, player/entity name tags, etc.) is difficult, if not nearly impossible to read. UI text and rendering are unaffected.
+
 ## License
 Licensed under the [MIT License](https://choosealicense.com/licenses/mit/).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-# Minecraft PSX Shaders
+# Minecraft PS1 (PSX) Shaders
+A Minecraft shader pack for both [OptiFine](https://optifine.net/) and [Iris](https://irisshaders.net/) that mimics the look and feel of PlayStation 1 graphics.
 
-A Minecraft shader pack that mimics PlayStation 1 graphics.
-
-[![PlayStation 1 Graphics in Minecraft (Minecraft PSX Shader Pack)](https://img.youtube.com/vi/6n_WGBEuRGY/0.jpg)](https://www.youtube.com/watch?v=6n_WGBEuRGY)
+## Video Demonstration
+<a href="https://www.youtube.com/watch?v=6n_WGBEuRGY" target="_blank"><strong>PlayStation 1 Graphics in Minecraft (Minecraft PSX Shader Pack)</strong><br><img src="https://img.youtube.com/vi/6n_WGBEuRGY/maxresdefault.jpg" width="640"></a>
 
 ## Installation
+Clone this Git repository (if you want the latest changes), or download the latest zipped release.
 
-Clone the repo and place it in your shaderpacks folder: `%appdata%\.minecraft\shaderpacks` or download the latest release and place it into your shaderpacks folder.
+Place the cloned repository folder or downloaded zip file in your `shaderpacks` folder.
+
+**※ NOTE:** If you don't know where your `shaderpacks` folder is located, you can open it using the "Shaders Folder" button (OptiFine) or the "Open Shader Pack Folder…" button (Iris) on the bottom left of your shader pack selection screen.
 
 ## Known Issues
+* Beacon beams tilt and do weird things when terrain vertex snapping is on due to [OptiFine issue #4905](https://github.com/sp614x/optifine/issues/4905).  If anyone knows the block entity ID of beacon beams or whatever it is to single it out in gbuffers_block, please let me know.
 
-- Beacon beams tilt and do weird things when terrain vertex snapping is on due to [this Optifine bug](https://github.com/sp614x/optifine/issues/4905).  If anyone knows the block entity ID of beacon beams or whatever it is to single it out in gbuffers_block, please let me know.
+* Texture affine map clamping ("Clamp Texcoord Bounds (OptiFine only)") is disabled by default in order to ensure that texture affine mapping works at all for Iris users. OptiFine users may want to re-enable this option in order to avoid extreme texture stretching on some geometry close to the camera at certain angles.
+	* The reason why this feature is broken is because it requires the use of a custom GLSL uniform (`texelSize`), but custom uniforms are not supported on Iris yet — see [Iris issue #1027](https://github.com/IrisShaders/Iris/issues/1027).
+
+* Texture affine mapping behaviour on Iris does not exactly match that of OptiFine's. All affine mapped textures on Iris warp in the opposite direction compared to OptiFine, though this is not noticeable without comparing the two side-by-side.
 
 ## License
-[MIT](https://choosealicense.com/licenses/mit/)
+Licensed under the [MIT License](https://choosealicense.com/licenses/mit/).

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Place the cloned repository folder or downloaded zip file in your `shaderpacks` 
 **※ NOTE:** If you don't know where your `shaderpacks` folder is located, you can open it using the "Shaders Folder" button (OptiFine) or the "Open Shader Pack Folder…" button (Iris) on the bottom left of your shader pack selection screen.
 
 ## Known Issues
-* Beacon beams tilt and do weird things when terrain vertex snapping is on due to [OptiFine issue #4905](https://github.com/sp614x/optifine/issues/4905).  If anyone knows the block entity ID of beacon beams or whatever it is to single it out in gbuffers_block, please let me know.
+* Beacon beams tilt and do weird things when terrain vertex snapping is on due to [OptiFine issue #4905](https://github.com/sp614x/optifine/issues/4905) (sp614x/optifine#4905).  If anyone knows the block entity ID of beacon beams or whatever it is to single it out in gbuffers_block, please let me know.
 
 * Texture affine map clamping ("Clamp Texcoord Bounds (OptiFine only)") is disabled by default in order to ensure that texture affine mapping works at all for Iris users. OptiFine users may want to re-enable this option in order to avoid extreme texture stretching on some geometry close to the camera at certain angles.
-	* The reason why this feature is broken is because it requires the use of a custom GLSL uniform (`texelSize`), but custom uniforms are not supported on Iris yet — see [Iris issue #1027](https://github.com/IrisShaders/Iris/issues/1027).
+	* The reason why this feature is broken is because it requires the use of a custom GLSL uniform (`texelSize`), but custom uniforms are not supported on Iris yet — see [Iris issue #1027](https://github.com/IrisShaders/Iris/issues/1027) (IrisShaders/Iris#1027).
 
 * Texture affine mapping behaviour on Iris does not exactly match that of OptiFine's. All affine mapped textures on Iris warp in the opposite direction compared to OptiFine, though this is not noticeable without comparing the two side-by-side.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Minecraft PS1 (PSX) Shaders
 A Minecraft shader pack for both [OptiFine](https://optifine.net/) and [Iris](https://irisshaders.net/) that mimics the look and feel of PlayStation 1 graphics.
 
+Tested to work with Minecraft 1.19.2 〜 1.7.10, but it most likely will work just fine with newer versions, too.
+
 ## Video Demonstration
 <a href="https://www.youtube.com/watch?v=6n_WGBEuRGY" target="_blank"><strong>PlayStation 1 Graphics in Minecraft (Minecraft PSX Shader Pack)</strong><br><img src="https://img.youtube.com/vi/6n_WGBEuRGY/maxresdefault.jpg" width="640"></a>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Place the cloned repository folder or downloaded zip file in your `shaderpacks` 
 
 * Texture affine mapping behaviour on Iris does not exactly match that of OptiFine's. All affine mapped textures on Iris warp in the opposite direction compared to OptiFine, though this is not noticeable without comparing the two side-by-side.
 
-* In-universe text (signs, player/entity name tags, etc.) is difficult, if not nearly impossible to read. UI text and rendering are unaffected.
+* In-universe text (signs, player/entity name tags, etc.) can be difficult, if not nearly impossible to read without zooming (or moving very close to the text in question) due to the mesh vertex distortion effect affecting the mesh that in-universe text is rendered to. Glow ink signs are notable for being the most illegible due to the fact that the glow ink effect is in itself rendered as a secondary mesh behind the already-existing text mesh.
+	* Text rendering on UI elements (chat, inventory screens, etc.) is completely unaffected.
 
 ## License
 Licensed under the [MIT License](https://choosealicense.com/licenses/mit/).

--- a/shaders/composite.fsh
+++ b/shaders/composite.fsh
@@ -95,7 +95,7 @@ void main() {
 	float fogDepth = depth * fog_distance - (fog_distance-1);
 	fogDepth = clamp(fogDepth, 0.0, 1.0);
 	#else
-	float fogDepth = sky;
+	float fogDepth = (sky) ? 1.0 : 0.0;
 	#endif
 	vec3 col = texture2D(colortex0, texcoord).rgb;
 	

--- a/shaders/gbuffers_basic.fsh
+++ b/shaders/gbuffers_basic.fsh
@@ -3,7 +3,6 @@
 #extension GL_EXT_gpu_shader4 : enable
 #extension GL_ARB_shader_texture_lod : enable
 
-uniform vec2 texelSize;
 varying vec4 texcoord;
 varying vec4 texcoordAffine;
 varying vec4 lmcoord;
@@ -14,8 +13,11 @@ varying vec4 normalMat;
 
 uniform sampler2D texture;
 uniform sampler2D lightmap;
+uniform float viewWidth;
+uniform float viewHeight;
 
 void main() {
+	vec2 texelSize = vec2(1.0/viewWidth, 1.0/viewHeight);
 	vec2 affine = AffineMapping(texcoordAffine, texcoord, texelSize, 2);
 
 	vec4 col = texture2D(texture, texcoord.xy) * color * (texture2D(lightmap, lmcoord.st) * 0.8 + 0.2);

--- a/shaders/gbuffers_clouds.fsh
+++ b/shaders/gbuffers_clouds.fsh
@@ -4,8 +4,6 @@
 #extension GL_EXT_gpu_shader4 : enable
 #extension GL_ARB_shader_texture_lod : enable
 
-uniform vec2 texelSize;
-
 varying vec4 texcoord;
 varying vec4 color;
 

--- a/shaders/gbuffers_entities.fsh
+++ b/shaders/gbuffers_entities.fsh
@@ -12,10 +12,10 @@ varying vec4 lmcoord;
 varying vec4 color;
 varying vec4 normalMat;
 
-
+uniform float viewWidth;
+uniform float viewHeight;
 uniform sampler2D texture;
 uniform sampler2D lightmap;
-uniform vec2 texelSize;
 uniform vec4 entityColor;
 uniform vec3 skyColor;
 
@@ -25,6 +25,7 @@ uniform vec3 skyColor;
 void main() {
 	#ifdef affine_mapping
 	#ifdef affine_clamp_enabled
+	vec2 texelSize = vec2(1.0/viewWidth, 1.0/viewHeight);
 	vec2 affine = AffineMapping(texcoordAffine, texcoord, texelSize, affine_clamp * 4.0);
 	#else
 	vec2 affine = texcoordAffine.xy / texcoordAffine.z;

--- a/shaders/gbuffers_hand.fsh
+++ b/shaders/gbuffers_hand.fsh
@@ -6,8 +6,6 @@
 #define gbuffers_solid
 #include "/shaders.settings"
 
-uniform vec2 texelSize;
-
 varying vec4 texcoord;
 varying vec4 lmcoord;
 varying vec4 color;

--- a/shaders/gbuffers_terrain.fsh
+++ b/shaders/gbuffers_terrain.fsh
@@ -6,7 +6,8 @@
 #define gbuffers_solid
 #include "/shaders.settings"
 
-uniform vec2 texelSize;
+uniform float viewWidth;
+uniform float viewHeight;
 
 varying vec4 texcoord;
 varying vec4 texcoordAffine;
@@ -21,6 +22,7 @@ uniform sampler2D lightmap;
 void main() {
 	#ifdef affine_mapping
 	#ifdef affine_clamp_enabled
+	vec2 texelSize = vec2(1.0/viewWidth, 1.0/viewHeight);
 	vec2 affine = AffineMapping(texcoordAffine, texcoord, texelSize, affine_clamp);
 	#else
 	vec2 affine = texcoordAffine.xy / texcoordAffine.z;

--- a/shaders/gbuffers_water.fsh
+++ b/shaders/gbuffers_water.fsh
@@ -6,7 +6,8 @@
 #define gbuffers_solid
 #include "/shaders.settings"
 
-uniform vec2 texelSize;
+uniform float viewWidth;
+uniform float viewHeight;
 
 varying vec4 texcoord;
 varying vec4 texcoordAffine;
@@ -21,6 +22,7 @@ uniform sampler2D lightmap;
 void main() {
 	#ifdef affine_mapping
 	#ifdef affine_clamp_enabled
+	vec2 texelSize = vec2(1.0/viewWidth, 1.0/viewHeight);
 	vec2 affine = AffineMapping(texcoordAffine, texcoord, texelSize, affine_clamp);
 	#else
 	vec2 affine = texcoordAffine.xy / texcoordAffine.z;

--- a/shaders/lang/en_US.lang
+++ b/shaders/lang/en_US.lang
@@ -1,6 +1,6 @@
 option.affine_mapping=Affine Mapping
 option.affine_clamp=Texcoord Bounds
-option.affine_clamp_enabled=Clamp Texcoord Bounds
+option.affine_clamp_enabled=Clamp Texcoord Bounds (OptiFine only)
 
 option.vertex_inaccuracy_terrain=Terrain Vertex Inaccuracy
 option.vertex_inaccuracy_entities=Entity Vertex Inaccuracy

--- a/shaders/lang/en_US.lang
+++ b/shaders/lang/en_US.lang
@@ -1,6 +1,6 @@
 option.affine_mapping=Affine Mapping
 option.affine_clamp=Texcoord Bounds
-option.affine_clamp_enabled=Clamp Texcoord Bounds (OptiFine only)
+option.affine_clamp_enabled=Clamp Texcoord Bounds
 
 option.vertex_inaccuracy_terrain=Terrain Vertex Inaccuracy
 option.vertex_inaccuracy_entities=Entity Vertex Inaccuracy

--- a/shaders/shaders.settings
+++ b/shaders/shaders.settings
@@ -4,7 +4,7 @@
 #ifdef gbuffers_solid
 	#define affine_mapping					//Toggles affine texture mapping
 	#define affine_clamp 2.0				//Adjusts texture coordinate bounds [0.0 1.0 2.0 3.0 4.0 5.0]
-	// #define affine_clamp_enabled			//Enables clamping of texture coordinate bounds to avoid extreme stretching. Disabled by default for now as it currently only works correctly on OptiFine. See README for more information. ※ TODO: Determine if there's some way to detect whether we're running on Iris or OptiFine from within GLSL code.
+	#define affine_clamp_enabled			//Enables clamping of texture coordinate bounds to avoid extreme stretching.
 #endif
 
 #ifdef gbuffers_terrain

--- a/shaders/shaders.settings
+++ b/shaders/shaders.settings
@@ -4,7 +4,7 @@
 #ifdef gbuffers_solid
 	#define affine_mapping					//Toggles affine texture mapping
 	#define affine_clamp 2.0				//Adjusts texture coordinate bounds [0.0 1.0 2.0 3.0 4.0 5.0]
-	// #define affine_clamp_enabled			//Enables clamping of texture coordinate bounds to avoid extreme stretching. Disabled by default for now as it currently only works correctly on OptiFine. See README for more information.
+	// #define affine_clamp_enabled			//Enables clamping of texture coordinate bounds to avoid extreme stretching. Disabled by default for now as it currently only works correctly on OptiFine. See README for more information. ※ TODO: Determine if there's some way to detect whether we're running on Iris or OptiFine from within GLSL code.
 #endif
 
 #ifdef gbuffers_terrain

--- a/shaders/shaders.settings
+++ b/shaders/shaders.settings
@@ -1,9 +1,10 @@
 /* PSX Shader by ckosmic */
+/* Modified by Karen/あけみ (akemin_dayo) for compatibility with Iris */
 
 #ifdef gbuffers_solid
 	#define affine_mapping					//Toggles affine texture mapping
 	#define affine_clamp 2.0				//Adjusts texture coordinate bounds [0.0 1.0 2.0 3.0 4.0 5.0]
-	#define affine_clamp_enabled			//Enables clamping of texture coordinate bounds to avoid extreme stretching
+	// #define affine_clamp_enabled			//Enables clamping of texture coordinate bounds to avoid extreme stretching. Disabled by default for now as it currently only works correctly on OptiFine. See README for more information.
 #endif
 
 #ifdef gbuffers_terrain

--- a/shaders/world1/gbuffers_skybasic.vsh
+++ b/shaders/world1/gbuffers_skybasic.vsh
@@ -1,1 +1,1 @@
-#include "/gbuffers_skybasic.csh"
+#include "/gbuffers_skybasic.vsh"


### PR DESCRIPTION
This PR adds Iris compatibility (fixing #3), but with texture affine map clamping disabled by default for all users, even those that are using OptiFine.

I've also rewritten and improved the README.md documentation.

~~Unfortunately, I am not currently aware if there is any way for us to determine from GLSL code whether we're running on Iris or OptiFine — if there is, it would be ideal to disable texture affine map clamping by default only for Iris users, but leave it enabled by default for OptiFine users.~~

※ Iris developers have confirmed that such a thing is impossible, and that they heavily discourage trying to do anything like that.